### PR TITLE
Only publish story.json during autominerva

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -125,6 +125,7 @@ process autominerva_story {
   output:
       tuple val(meta), file(image), file('story.json')
   publishDir "$params.outdir/$workflow.runName",
+    pattern: 'story.json',
     saveAs: {filename -> "${meta.id}/$workflow.runName/story.json"}
   stub: 
   """


### PR DESCRIPTION
This fixes an issue where the autominerva process was outputting image to the publishDir named as story.json, overwriting the actual json file. This is fixed by adding a pattern to only output the story.json file.