### PR TITLE
[ORCA-249] Push docker image to ghcr and use trivy docker scan tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,20 @@ jobs:
               registry: ghcr.io
               username: ${{ github.actor }}
               password: ${{ secrets.GITHUB_TOKEN }}
+              
+          - name: Extract Docker metadata
+            id: metadata
+            uses: docker/metadata-action@v4
+            with:
+              images: |
+                ghcr.io/${{ github.repository }}
+              tags: |
+                type=semver,pattern={{version}}
+                type=semver,pattern={{major}}.{{minor}} 
+                type=semver,pattern={{major}}
+                type=ref,event=branch
+                type=sha
+                latest
 
           - name: Build and push to GHCR
             uses: docker/build-push-action@v4
@@ -38,6 +52,7 @@ jobs:
               context: ./docker
               file: ./docker/Dockerfile
               push: true
-              tags: ghcr.io/adamjtaylor/htan-artist:latest
+              tags: ${{ steps.metadata.outputs.tags }}
+              labels: ${{ steps.metadata.outputs.labels }}
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - 'main'
-     - 'orca-249-push-to-ghcr'
     paths:
      - 'docker/**'
      - '.github/workflows/ci.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,14 @@ on:
 
 jobs:
       docker:
-        permissions: write-all
         runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          packages: write
+          
+        defaults:
+          run:
+            working-directory: './docker'
 
         steps:
           - name: Checkout GitHub Action
@@ -25,16 +31,17 @@ jobs:
             uses: docker/login-action@v2
             with:
               registry: ghcr.io
-              username: ${{github.actor}}
-              password: ${{secrets.GITHUB_TOKEN}}
-              logout: false
+              username: ${{ github.actor }}
+              password: ${{ secrets.GITHUB_TOKEN }}
 
           - name: Build and push to GHCR
             uses: docker/build-push-action@v4
             with:
-              context: .
+              context: ./docker
               file: ./docker/Dockerfile
               push: true
               tags: ghcr.io/adamjtaylor/htan-artist:latest
+              cache-from: type=local,src=/tmp/.buildx-cache
+              cache-to: type=local,dest=/tmp/.buildx-cache
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
             uses: docker/build-push-action@v4
             with:
               context: ./docker
-              file: ./docker/Dockerfile
               push: true
               tags: ${{ steps.metadata.outputs.tags }}
               labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,5 @@ jobs:
               file: ./docker/Dockerfile
               push: true
               tags: ghcr.io/adamjtaylor/htan-artist:latest
-              cache-from: type=gha
-              cache-to: type=gha,mode=max
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,43 +3,34 @@ name: ci
 on:
   push:
     branches:
-      - 'main'
+      - 'orca-249-push-to-ghcr'
       - 'dsl2'
     paths:
      - 'docker/**'
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to quay.io
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: adamjtaylor
-          password: ${{ secrets.QUAY_PASSWORD }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker
-          push: true
-          tags: |
-            adamjtaylor/htan-artist:latest
-            quay.io/adamjtaylor/htan-artist:latest
+      docker:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout GitHub Action
+            uses: actions/checkout@v3
+
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v1
+
+          - name: Login to GitHub Container Registry
+            uses: docker/login-action@v1
+            with:
+              registry: ghcr.io
+              username: ${{github.actor}}
+              password: ${{secrets.GITHUB_TOKEN}}
+
+          - name: Build and push
+            uses: docker/build-push-action@v4
+            with:
+              context: ./docker
+              push: true
+              tags: |
+                ghcr.io/adamjtaylor/htan-artist:latest
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         permissions:
           contents: read
           packages: write
-          
+
         defaults:
           run:
             working-directory: './docker'
@@ -41,7 +41,7 @@ jobs:
               file: ./docker/Dockerfile
               push: true
               tags: ghcr.io/adamjtaylor/htan-artist:latest
-              cache-from: type=local,src=/tmp/.buildx-cache
-              cache-to: type=local,dest=/tmp/.buildx-cache
+              cache-from: type=gha
+              cache-to: type=gha,mode=max
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,4 @@ jobs:
               ignore-unchanged: true
               only-severities: critical,high
               write-comment: true
-              token: ${{ secrets.GITHUB_TOKEN }}
+              github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - 'dsl2'
-     - 'orca-249-push-to-ghcr'
     paths:
      - 'docker/**'
      - '.github/workflows/ci.yml'
@@ -13,8 +12,6 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # Use `latest` as the tag to compare to if empty, assuming that it's already pushed
-  COMPARE_TAG: latest
 
 jobs:
       docker:
@@ -52,23 +49,11 @@ jobs:
                 type=sha
                 latest
 
-          #- name: Build and push to GHCR
-          #  uses: docker/build-push-action@v4
-          #  with:
-          #    context: ./docker
-          #    file: ./docker/Dockerfile
-          #    push: true
-          #    tags: ${{ steps.metadata.outputs.tags }}
-          #    labels: ${{ steps.metadata.outputs.labels }}
-
-          - name: Docker Scout
-            id: docker-scout
-            uses: docker/scout-action@v0.18.1
+          - name: Build and push to GHCR
+            uses: docker/build-push-action@v4
             with:
-              command: recommendations, compare
-              image: ${{ steps.metadata.outputs.tags }}
-              to-latest: true
-              ignore-unchanged: true
-              only-severities: critical,high
-              dockerhub-user: ${{ github.actor }}
-              dockerhub-password: ${{ secrets.GITHUB_TOKEN }}
+              context: ./docker
+              file: ./docker/Dockerfile
+              push: true
+              tags: ${{ steps.metadata.outputs.tags }}
+              labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
 jobs:
       docker:
         runs-on: ubuntu-latest
+        defaults:
+          run:
+            working-directory: './docker'
         steps:
           - name: Checkout GitHub Action
             uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: ci
 
 on:
   push:
-    branches:
-      - 'orca-249-push-to-ghcr'
-      - 'dsl2'
+    branches: "*"
     paths:
      - 'docker/**'
 
@@ -25,7 +23,7 @@ jobs:
               username: ${{github.actor}}
               password: ${{secrets.GITHUB_TOKEN}}
 
-          - name: Build and push to GHCR
+          - name: Build and push to GHCRg
             uses: docker/build-push-action@v4
             with:
               context: ./docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
      - 'docker/**'
      - '.github/workflows/ci.yml'
 
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  # Use `latest` as the tag to compare to if empty, assuming that it's already pushed
+  COMPARE_TAG: latest
+
 jobs:
       docker:
         runs-on: ubuntu-latest
@@ -28,7 +35,7 @@ jobs:
           - name: Login to GitHub Container Registry (GHCR)
             uses: docker/login-action@v2
             with:
-              registry: ghcr.io
+              registry: ${{ env.REGISTRY }}
               username: ${{ github.actor }}
               password: ${{ secrets.GITHUB_TOKEN }}
               
@@ -37,7 +44,7 @@ jobs:
             uses: docker/metadata-action@v4
             with:
               images: |
-                ghcr.io/${{ github.repository }}
+                ${{ env.REGISTRY }}/${{ github.repository }}
               tags: |
                 type=semver,pattern={{version}}
                 type=semver,pattern={{major}}.{{minor}} 
@@ -55,4 +62,14 @@ jobs:
               tags: ${{ steps.metadata.outputs.tags }}
               labels: ${{ steps.metadata.outputs.labels }}
 
-
+          - name: Docker Scout
+            id: docker-scout
+            uses: docker/scout-action@v0.18
+            with:
+              command: compare
+              image: ${{ steps.metadata.outputs.tags }}
+              to: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMPARE_TAG }}
+              ignore-unchanged: true
+              only-severities: critical,high
+              write-comment: true
+              token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,7 @@ jobs:
             id: metadata
             uses: docker/metadata-action@v4
             with:
-              images: |
-                ${{ env.REGISTRY }}/${{ github.repository }}
+              images: ${{ env.REGISTRY }}/${{ github.repository }}
               tags: |
                 type=semver,pattern={{version}}
                 type=semver,pattern={{major}}.{{minor}} 
@@ -67,10 +66,7 @@ jobs:
             id: docker-scout
             uses: docker/scout-action@v0.18.1
             with:
-              command: cves,recommendations,compare
+              command: recommendations
               image: ${{ steps.metadata.outputs.tags }}
-              to: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMPARE_TAG }}
               ignore-unchanged: true
               only-severities: critical,high
-              #write-comment: true
-              #github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           contents: read
           packages: write
           id-token: write
+          pull-requests: write
 
         defaults:
           run:
@@ -64,12 +65,12 @@ jobs:
 
           - name: Docker Scout
             id: docker-scout
-            uses: docker/scout-action@v0.20.0
+            uses: docker/scout-action@v0.18.1
             with:
-              command: compare
+              command: cves,recommendations,compare
               image: ${{ steps.metadata.outputs.tags }}
               to: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMPARE_TAG }}
               ignore-unchanged: true
               only-severities: critical,high
-              write-comment: true
-              github-token: ${{ secrets.GITHUB_TOKEN }}
+              #write-comment: true
+              #github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
           - name: Docker Scout
             id: docker-scout
-            uses: docker/scout-action@v0.18
+            uses: docker/scout-action@v0.20.0
             with:
               command: compare
               image: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,7 @@ on:
      - '.github/workflows/ci.yml'
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
       docker:
@@ -20,7 +18,6 @@ jobs:
           contents: read
           packages: write
           id-token: write
-          pull-requests: write
 
         defaults:
           run:
@@ -46,6 +43,7 @@ jobs:
                 type=semver,pattern={{version}}
                 type=semver,pattern={{major}}.{{minor}} 
                 type=semver,pattern={{major}}
+                type=ref,event=branch
                 type=sha
                 latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
           - name: Set up Docker Buildx
             uses: docker/setup-buildx-action@v1
 
-          - name: Login to GitHub Container Registry
+          - name: Login to GitHub Container Registry (GHCR)
             uses: docker/login-action@v1
             with:
               registry: ghcr.io
               username: ${{github.actor}}
               password: ${{secrets.GITHUB_TOKEN}}
 
-          - name: Build and push
+          - name: Build and push to GHCR
             uses: docker/build-push-action@v4
             with:
               context: ./docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,24 @@ jobs:
           - name: Checkout GitHub Action
             uses: actions/checkout@v3
 
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v1
+
           - name: Login to GitHub Container Registry (GHCR)
             uses: docker/login-action@v1
             with:
               registry: ghcr.io
               username: ${{github.actor}}
               password: ${{secrets.GITHUB_TOKEN}}
+              logout: false
 
-          - name: 'Build Inventory Image'
-            run: |
-              docker build . --tag ghcr.io/adamjtaylor/htan-artist:latest
-              docker push ghcr.io/adamjtaylor/htan-artist:latest
+          - name: Build and push to GHCRg
+            uses: docker/build-push-action@v4
+            with:
+              context: ./docker
+              push: true
+              tags: |
+                adamjtaylor/htan-artist:latest
+                ghcr.io/adamjtaylor/htan-artist:latest
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,9 @@ on:
 
 jobs:
       docker:
+        permissions: write-all
         runs-on: ubuntu-latest
-        defaults:
-          run:
-            working-directory: './docker'
+
         steps:
           - name: Checkout GitHub Action
             uses: actions/checkout@v3
@@ -23,20 +22,19 @@ jobs:
             uses: docker/setup-buildx-action@v1
 
           - name: Login to GitHub Container Registry (GHCR)
-            uses: docker/login-action@v1
+            uses: docker/login-action@v2
             with:
               registry: ghcr.io
               username: ${{github.actor}}
               password: ${{secrets.GITHUB_TOKEN}}
               logout: false
 
-          - name: Build and push to GHCRg
+          - name: Build and push to GHCR
             uses: docker/build-push-action@v4
             with:
-              context: ./docker
+              context: .
+              file: ./docker/Dockerfile
               push: true
-              tags: |
-                adamjtaylor/htan-artist:latest
-                ghcr.io/adamjtaylor/htan-artist:latest
+              tags: ghcr.io/adamjtaylor/htan-artist:latest
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: ci
 on:
   push:
     branches:
-     - 'dsl2'
+     - 'main'
+     - 'orca-249-push-to-ghcr'
     paths:
      - 'docker/**'
      - '.github/workflows/ci.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,20 +52,23 @@ jobs:
                 type=sha
                 latest
 
-          - name: Build and push to GHCR
-            uses: docker/build-push-action@v4
-            with:
-              context: ./docker
-              file: ./docker/Dockerfile
-              push: true
-              tags: ${{ steps.metadata.outputs.tags }}
-              labels: ${{ steps.metadata.outputs.labels }}
+          #- name: Build and push to GHCR
+          #  uses: docker/build-push-action@v4
+          #  with:
+          #    context: ./docker
+          #    file: ./docker/Dockerfile
+          #    push: true
+          #    tags: ${{ steps.metadata.outputs.tags }}
+          #    labels: ${{ steps.metadata.outputs.labels }}
 
           - name: Docker Scout
             id: docker-scout
             uses: docker/scout-action@v0.18.1
             with:
-              command: recommendations
+              command: recommendations, compare
               image: ${{ steps.metadata.outputs.tags }}
+              to-latest: true
               ignore-unchanged: true
               only-severities: critical,high
+              dockerhub-user: ${{ github.actor }}
+              dockerhub-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
                 type=semver,pattern={{version}}
                 type=semver,pattern={{major}}.{{minor}} 
                 type=semver,pattern={{major}}
-                type=ref,event=branch
                 type=sha
                 latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: ci
 
 on:
   push:
-    branches: "*"
+    branches:
+     - 'dsl2'
+     - 'orca-249-push-to-ghcr'
     paths:
      - 'docker/**'
+     - '.github/workflows/ci.yml'
 
 jobs:
       docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         permissions:
           contents: read
           packages: write
+          id-token: write
 
         defaults:
           run:
@@ -23,9 +24,6 @@ jobs:
         steps:
           - name: Checkout GitHub Action
             uses: actions/checkout@v3
-
-          - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v1
 
           - name: Login to GitHub Container Registry (GHCR)
             uses: docker/login-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
           - name: Checkout GitHub Action
             uses: actions/checkout@v3
 
-          - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v1
-
           - name: Login to GitHub Container Registry (GHCR)
             uses: docker/login-action@v1
             with:
@@ -26,12 +23,9 @@ jobs:
               username: ${{github.actor}}
               password: ${{secrets.GITHUB_TOKEN}}
 
-          - name: Build and push to GHCRg
-            uses: docker/build-push-action@v4
-            with:
-              context: ./docker
-              push: true
-              tags: |
-                ghcr.io/adamjtaylor/htan-artist:latest
+          - name: 'Build Inventory Image'
+            run: |
+              docker build . --tag ghcr.io/adamjtaylor/htan-artist:latest
+              docker push ghcr.io/adamjtaylor/htan-artist:latest
 
 

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -5,11 +5,11 @@ on:
       branches:
        - 'dsl2'
        - 'orca-249-push-to-ghcr'
-       
+
 env:
     # Use docker.io for Docker Hub if empty
     REGISTRY: ghcr.io
-    IMAGE_NAME: ${{ github.repository }}
+    IMAGE_NAME: sage-bionetowk
     IMAGE_TAG: latest
     # Use `latest` as the tag to compare to if empty, assuming that it's already pushed
     COMPARE_TAG: latest
@@ -28,40 +28,46 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+            images: ${{ env.REGISTRY }}/${{ github.repository }}
+
       - name: Pull the image
         run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          docker pull ${{ steps.metadata.outputs.tags }}
 
       # Deliberately chosen master here to keep up-to-date.
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          image-ref: ${{ steps.metadata.outputs.tags }}
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
           limit-severities-for-sarif: true
           format: template
           template: '@/contrib/sarif.tpl'
-          output: trivy-results-${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}.sarif
+          output: trivy-results-${{ steps.metadata.outputs.tags }}.sarif
 
       # Show all detected issues.
       # Note this will show a lot more, including major un-fixed ones.
       - name: Run Trivy vulnerability scanner for local output
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          image-ref: ${{ steps.metadata.outputs.tags }}
           format: table
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: trivy-results-${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}.sarif
-          category: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} image
+          sarif_file: trivy-results-${{ steps.metadata.outputs.tags }}.sarif
+          category: ${{ steps.metadata.outputs.tags }} image
           wait-for-processing: true
 
       - name: Detain results for debug if needed
         uses: actions/upload-artifact@v3
         with:
-          name: trivy-results-${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}.sarif
-          path: trivy-results-${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}.sarif
+          name: trivy-results-${{ steps.metadata.outputs.tags }}.sarif
+          path: trivy-results-${{ steps.metadata.outputs.tags }}.sarif
           if-no-files-found: error

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -2,10 +2,9 @@ name: Scan image
 
 on:
     push:
-      branches: [ "dsl2" ]
+      branches: [ "main" ]
     pull_request:
-      # The branches below must be a subset of the branches above
-      branches: [ "dsl2" ]
+      branches: [ "main" ]
     schedule:
       - cron: '32 12 * * 2' # every tuesday at 12:32 UTC time
 

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -49,6 +49,7 @@ jobs:
           format: template
           template: '@/contrib/sarif.tpl'
           output: trivy-results.sarif
+          timeout: 20m
 
       # Show all detected issues.
       # Note this will show a lot more, including major un-fixed ones.
@@ -57,6 +58,7 @@ jobs:
         with:
           image-ref: ${{ steps.metadata.outputs.tags }}
           format: table
+          timeout: 20m
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -15,8 +15,10 @@ env:
     COMPARE_TAG: latest
 
 jobs:
-  trivy-edge:
+  trivy:
     name:  Run Trivy vulnerability scanner
+    permissions:
+        security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     continue-on-error: true
 
@@ -46,8 +48,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
           limit-severities-for-sarif: true
-          format: template
-          template: '@/contrib/sarif.tpl'
+          format: sarif
           output: trivy-results.sarif
           timeout: 20m
 

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -33,12 +33,12 @@ jobs:
         uses: docker/metadata-action@v4
         with:
             images: ${{ env.REGISTRY }}/${{ github.repository }}
+            tags: ${{ env.IMAGE_TAG }}
 
       - name: Pull the image
         run: |
           docker pull ${{ steps.metadata.outputs.tags }}
 
-      # Deliberately chosen master here to keep up-to-date.
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@master
         with:
@@ -48,7 +48,7 @@ jobs:
           limit-severities-for-sarif: true
           format: template
           template: '@/contrib/sarif.tpl'
-          output: trivy-results-${{ steps.metadata.outputs.tags }}.sarif
+          output: trivy-results.sarif
 
       # Show all detected issues.
       # Note this will show a lot more, including major un-fixed ones.
@@ -61,13 +61,13 @@ jobs:
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: trivy-results-${{ steps.metadata.outputs.tags }}.sarif
+          sarif_file: trivy-results.sarif
           category: ${{ steps.metadata.outputs.tags }} image
           wait-for-processing: true
 
       - name: Detain results for debug if needed
         uses: actions/upload-artifact@v3
         with:
-          name: trivy-results-${{ steps.metadata.outputs.tags }}.sarif
-          path: trivy-results-${{ steps.metadata.outputs.tags }}.sarif
+          name: trivy-results.sarif
+          path: trivy-results.sarif
           if-no-files-found: error

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -2,17 +2,16 @@ name: Scan image
 
 on:
     push:
-      branches:
-       - 'dsl2'
-       - 'orca-249-push-to-ghcr'
+      branches: [ "dsl2" ]
+    pull_request:
+      # The branches below must be a subset of the branches above
+      branches: [ "dsl2" ]
+    schedule:
+      - cron: '32 12 * * 2' # every tuesday at 12:32 UTC time
 
 env:
-    # Use docker.io for Docker Hub if empty
     REGISTRY: ghcr.io
-    IMAGE_NAME: sage-bionetowk
-    IMAGE_TAG: latest
-    # Use `latest` as the tag to compare to if empty, assuming that it's already pushed
-    COMPARE_TAG: latest
+    IMAGE_TAG: latest # scan just latest image
 
 jobs:
   trivy:
@@ -20,7 +19,6 @@ jobs:
     permissions:
         security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Login to GitHub Container Registry
@@ -50,16 +48,15 @@ jobs:
           limit-severities-for-sarif: true
           format: sarif
           output: trivy-results.sarif
-          timeout: 20m
+          timeout: 20m # trivy default timeout is 5m, we need longer for our image
 
       # Show all detected issues.
-      # Note this will show a lot more, including major un-fixed ones.
       - name: Run Trivy vulnerability scanner for local output
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ steps.metadata.outputs.tags }}
           format: table
-          timeout: 20m
+          timeout: 20m # trivy default timeout is 5m, we need longer for our image
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -1,0 +1,67 @@
+name: Scan image
+
+on:
+    push:
+      branches:
+       - 'dsl2'
+       - 'orca-249-push-to-ghcr'
+       
+env:
+    # Use docker.io for Docker Hub if empty
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository }}
+    IMAGE_TAG: latest
+    # Use `latest` as the tag to compare to if empty, assuming that it's already pushed
+    COMPARE_TAG: latest
+
+jobs:
+  trivy-edge:
+    name:  Run Trivy vulnerability scanner
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull the image
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+      # Deliberately chosen master here to keep up-to-date.
+      - name: Run Trivy vulnerability scanner for any major issues
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          format: template
+          template: '@/contrib/sarif.tpl'
+          output: trivy-results-${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}.sarif
+
+      # Show all detected issues.
+      # Note this will show a lot more, including major un-fixed ones.
+      - name: Run Trivy vulnerability scanner for local output
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          format: table
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-results-${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}.sarif
+          category: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} image
+          wait-for-processing: true
+
+      - name: Detain results for debug if needed
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivy-results-${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}.sarif
+          path: trivy-results-${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}.sarif
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HTAN Artist
 
-A NextFlow piepline to run image rendering process to generate resources for the [HTAN Portal](https://github.com/ncihtan/htan-portal).
+A NextFlow pipeline to run image rendering process to generate resources for the [HTAN Portal](https://github.com/ncihtan/htan-portal).
 
 - Converts bioformats files into OME-TIFF
 - Generates a `story.json` file using [Auto-Minerva](https://github.com/jmuhlich/auto-minerva)
@@ -10,12 +10,12 @@ A NextFlow piepline to run image rendering process to generate resources for the
 - `--he` assumes the channel is a brighfield microscopy image of H&E stained tissue and uses a fixed, unscaled `story.json` and a custom color legend
 - `--input` can be the path to an image (with `*` wildcards) or a csv manifest of cloud storage uris (one per line).
 
-A Docker container ([adamjtaylor/htan-artist](https://hub.docker.com/repository/docker/adamjtaylor/htan-artist)) is used to ensure reproducibility.
+A Docker container ([ghcr.io/sage-bionetworks-workflows/nf-artist](https://github.com/sage-bionetworks-workflows/nf-artist/pkgs/container/nf-artist)) is used to ensure reproducibility.
 
 ## Example usage
 
 ```
-nextflow run adamjtaylor/htan-artist --input_path <path-to-image> --outdir <output-directory> --all
+nextflow run ghcr.io/sage-bionetworks-workflows/nf-artist --input_path <path-to-image> --outdir <output-directory> --all
 ```
 
 ## Options
@@ -45,8 +45,8 @@ nextflow run adamjtaylor/htan-artist --input_path <path-to-image> --outdir <outp
 
 ### Test docker container
 
-`docker run -ti adamjtaylor/htan-artist`
+`docker run -ti ghcr.io/sage-bionetworks-workflows/nf-artist`
 
 ## Build docker container
 
-`docker build -t adamjtaylor/htan-artist docker/`
+`docker build -t ghcr.io/sage-bionetworks-workflows/nf-artist docker/`

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - scikit-image
   - pandas
   - pooch
-  - zarr>=2.11.0
+  - zarr
   - cython
   - pyinstaller
   - altair
@@ -29,6 +29,6 @@ dependencies:
   - raw2ometiff
   - pip
   - imagemagick
-  - tiffslide=2.2.0
+  - tiffslide=2.1.2
   - libvips
   - estimagic

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - scikit-image
   - pandas
   - pooch
-  - zarr
+  - zarr>=2.11.0
   - cython
   - pyinstaller
   - altair
@@ -29,6 +29,6 @@ dependencies:
   - raw2ometiff
   - pip
   - imagemagick
-  - tiffslide
+  - tiffslide=2.2.0
   - libvips
   - estimagic

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 // nextflow.config
 
-process.container = 'adamjtaylor/htan-artist'
+process.container = 'ghcr.io/sage-bionetworks-workflows/nf-artist:latest'
 docker.enabled = true
 
 profiles {


### PR DESCRIPTION
**Purpose:** This PR pushes the docker image to GHCR and also uses [trivy-action](https://github.com/aquasecurity/trivy-action) to scan the docker images whenever changes are made to `dsl2` branch, and also scans on a weekly basis. Please ignore the millions of commits, will squash them when this is approved to merge.

You can see a sample output of high/critical scans from trivy under the Security Tab (here on github) -> Code scanning -> Search for the branch orca-249-push-to-ghcr. 

Note that when we eventually merge dsl2 -> main, the branches on the workflows will have to be updated to `main`