### PR TITLE
Simplify output directory structure

### DIFF
--- a/modules/autominerva_story.nf
+++ b/modules/autominerva_story.nf
@@ -5,7 +5,7 @@ process autominerva_story {
       tuple val(meta), file(image), file('story.json')
   publishDir "$params.outdir/$workflow.runName",
     pattern: 'story.json',
-    saveAs: {filename -> "${meta.id}/$workflow.runName/story.json"}
+    saveAs: {filename -> "${meta.id}/story.json"}
   stub: 
   """
   touch story.json

--- a/modules/autominerva_story.nf
+++ b/modules/autominerva_story.nf
@@ -3,9 +3,9 @@ process autominerva_story {
       tuple val(meta), file(image) 
   output:
       tuple val(meta), file(image), file('story.json')
-  publishDir "$params.outdir/$workflow.runName",
+  publishDir "$params.outdir",
     pattern: 'story.json',
-    saveAs: {filename -> "${meta.id}/story.json"}
+    saveAs: {filename -> "${meta.id}/minerva/story.json"}
   stub: 
   """
   touch story.json

--- a/modules/make_miniature.nf
+++ b/modules/make_miniature.nf
@@ -5,7 +5,7 @@ process make_miniature {
   output:
       tuple val(meta), file('miniature.jpg')
   publishDir "$params.outdir/$workflow.runName",
-    saveAs: {filename -> "${meta.id}/$workflow.runName/thumbnail.jpg"}
+    saveAs: {filename -> "${meta.id}/thumbnail.jpg"}
   stub:
   """
   mkdir data

--- a/modules/make_miniature.nf
+++ b/modules/make_miniature.nf
@@ -3,13 +3,13 @@ process make_miniature {
   input:
       tuple val(meta), file(image) 
   output:
-      tuple val(meta), file('miniature.jpg')
-  publishDir "$params.outdir/$workflow.runName",
+      tuple val(meta), file('thumbnail.jpg')
+  publishDir "$params.outdir",
     saveAs: {filename -> "${meta.id}/thumbnail.jpg"}
   stub:
   """
   mkdir data
-  touch data/miniature.jpg
+  touch data/thumbnail.jpg
   """
   script:
   if ( meta.he){
@@ -23,12 +23,12 @@ process make_miniature {
     slide = TiffSlide('$image')
 
     thumb = slide.get_thumbnail((512, 512))
-    thumb.save('miniature.jpg')
+    thumb.save('thumbnail.jpg')
     """
   } else {
     """
     python3 /miniature/bin/paint_miniature.py \
-      $image 'miniature.jpg' \
+      $image 'thumbnail.jpg' \
       --level $params.level \
       --dimred $params.dimred \
       --colormap $params.colormap \

--- a/modules/minerva.nf
+++ b/modules/minerva.nf
@@ -29,7 +29,7 @@ process STORY {
 
 process RENDER {
     label "process_medium"
-    publishDir "$params.outdir/$workflow.runName",
+    publishDir "$params.outdir",
         mode: 'move' 
     
     echo params.echo

--- a/modules/render_pyramid.nf
+++ b/modules/render_pyramid.nf
@@ -4,7 +4,7 @@ process render_pyramid {
   output:
       tuple val(meta), path('minerva')
   publishDir "$params.outdir/$workflow.runName",
-    saveAs: {filename -> "${meta.id}/$workflow.runName/minerva"}
+    saveAs: {filename -> "${meta.id}/minerva"}
   stub:
   """
   mkdir minerva

--- a/modules/render_pyramid.nf
+++ b/modules/render_pyramid.nf
@@ -3,7 +3,7 @@ process render_pyramid {
       tuple val(meta), file(image), file (story)
   output:
       tuple val(meta), path('minerva')
-  publishDir "$params.outdir/$workflow.runName",
+  publishDir "$params.outdir",
     saveAs: {filename -> "${meta.id}/minerva"}
   stub:
   """


### PR DESCRIPTION
Our current output structure is as follows

```
outdir
    workflow.runName
        meta.id
            workflow.runName
                story.json
                thumbnail.jpeg
                minerva
                    index.html
                    exhibit.json
                    Group1...
                        tile1.jpeg
                        ...
                    ...
 ```
 
 The intention of the two occurrences of run name were
1. To allow for multiple runs within the same outdir (does not seem very Nextflowy - we should just change the outdir if we want.
2. To allow for versions to be specified by the run name once the assets are staged in our public bucket (this works to a point but does not really get used and provides a very confusing output structure

I'm proposing this is simplified by removing both of these nested run names.
Story.json will also be moved under the minerva directory

The new structure would be 

```
outdir
    meta.id
        thumbnail.jpeg
        minerva
            index.html
            exhibit.json
            story.json
            Group1...
                tile1.jpeg
                ...
            ...

```