### PR TITLE
Use id column from samplesheet if specified

### DIFF
--- a/subworkflows/samplesheet_split.nf
+++ b/subworkflows/samplesheet_split.nf
@@ -9,7 +9,12 @@ workflow SAMPLESHEET_SPLIT {
         .map { 
             row -> 
             def meta = [:]
-            meta.id = file(row.image).simpleName
+            if (row.id ) {
+                meta.id = row.id
+            } else {
+                meta.id = file(row.image).simpleName
+
+            }
             meta.ome = row.image ==~ /.+\.ome\.tif{1,2}$/
             meta.convert = row.convert.toBoolean()
             meta.he = row.he.toBoolean()


### PR DESCRIPTION
For HTAN we stage the outputs from nf-artist using the original synapse ID of the file as part of the URL, for example:

https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/thumbnail.png

To allow for nf-artist to by not dependent on Synapse the current samplesheet takes a column `image` that is the path to a staged image.

It would be advantageous for HTAN and other projects to allow for a `id` column in the samplesheet that gets taken into the meta map as `id` if specified, if not specified the current behavior of using the image `simpleName` is used.