### PR TITLE
Fix example command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Docker container ([ghcr.io/sage-bionetworks-workflows/nf-artist](https://githu
 ## Example usage
 
 ```
-nextflow run ghcr.io/sage-bionetworks-workflows/nf-artist --input <path-to-samplesheet> --outdir <output-directory>
+nextflow run Sage-Bionetworks-Workflows/nf-artist --input <path-to-samplesheet> --outdir <output-directory>
 ```
 
 


### PR DESCRIPTION
Fixes the README.md so that the example command points to the repo not the container