### PR TITLE
Use `id` from samplesheet if present

### DIFF
--- a/subworkflows/samplesheet_split.nf
+++ b/subworkflows/samplesheet_split.nf
@@ -9,7 +9,11 @@ workflow SAMPLESHEET_SPLIT {
         .map { 
             row -> 
             def meta = [:]
-            meta.id = file(row.image).simpleName
+            if (row.id ) {
+                meta.id = row.id
+            } else {
+                meta.id = file(row.image).simpleName
+            }
             meta.ome = row.image ==~ /.+\.ome\.tif{1,2}$/
             meta.convert = row.convert.toBoolean()
             meta.he = row.he.toBoolean()


### PR DESCRIPTION
These was supposed to have been implemented in cleanup but was not.

This allows for an optional column `id` in the samplesheet which if present is used to name output directories per file. If not present the `simpleName` (basename with no extensions) is used.