### PR TITLE
Convert H&E thumbnail to RGB if RGBA or P mode

### DIFF
--- a/modules/make_miniature.nf
+++ b/modules/make_miniature.nf
@@ -24,6 +24,8 @@ process make_miniature {
     slide = TiffSlide('$image')
 
     thumb = slide.get_thumbnail((512, 512))
+    if thumb.mode in ("RGBA", "P"): 
+      thumb = thumb.convert("RGB")
     thumb.save('miniature.jpg')
     """
   } else {


### PR DESCRIPTION
In recent nextflow runs, I have noticed that some H&E images can present as RGBA (ie with transparency). This causes an error on saving the thumbnail.

```
Traceback (most recent call last):
  File "/venv/lib/python3.10/site-packages/PIL/JpegImagePlugin.py", line 639, in _save
    rawmode = RAWMODE[im.mode]
KeyError: 'RGBA'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/tmp/nxf.OrYoBLjy6B/.command.sh", line 10, in
    thumb.save('miniature.jpg')
  File "/venv/lib/python3.10/site-packages/PIL/Image.py", line 2413, in save
    save_handler(self, fp, filename)
  File "/venv/lib/python3.10/site-packages/PIL/JpegImagePlugin.py", line 642, in _save
    raise OSError(msg) from e
OSError: cannot write mode RGBA as JPEG
```

This PR checks the thumbnail format and converts to RGB if RGBA or P format.