### PR TITLE
Change outut structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ The samplesheet specified in the `input` parameter should be a CSV file with the
 - `convert`: [boolean] Should the image be converted to a OME-TIFF
 - `he`: [boolean] Is the image a H&E image
 - `minerva`: [boolean] Should a Minerva story be generated
-- `miniatuee`: [boolean] Should a Miniature thumbnail be generated
+- `miniature`: [boolean] Should a Miniature thumbnail be generated
 - `id`: *optional* [string] A custom identifier to replace image simpleName in output directory structure 
 

--- a/data/test_samplesheet.csv
+++ b/data/test_samplesheet.csv
@@ -1,3 +1,3 @@
 image,convert,he,minerva,miniature,id
-datas/exemplar-001_small.tif,true,false,true,true,cycif
+data/exemplar-001_small.tif,true,false,true,true,cycif
 data/CMU-1-Small-Region.svs,true,true,true,true,h_and_e

--- a/modules/autominerva_story.nf
+++ b/modules/autominerva_story.nf
@@ -5,9 +5,9 @@ process autominerva_story {
       tuple val(meta), file(image) 
   output:
       tuple val(meta), file(image), file('story.json')
-  publishDir "$params.outdir/$workflow.runName",
+  publishDir "$params.outdir",
       pattern: 'story.json',
-      saveAs: {filename -> "${meta.id}/$workflow.runName/story.json"}
+      saveAs: {filename -> "${meta.id}/story.json"}
   stub: 
   """
   touch story.json

--- a/modules/make_miniature.nf
+++ b/modules/make_miniature.nf
@@ -5,8 +5,8 @@ process make_miniature {
       tuple val(meta), file(image) 
   output:
       tuple val(meta), file('miniature.jpg')
-  publishDir "$params.outdir/$workflow.runName",
-    saveAs: {filename -> "${meta.id}/$workflow.runName/thumbnail.jpg"}
+  publishDir "$params.outdir",
+    saveAs: {filename -> "${meta.id}/thumbnail.jpg"}
   stub:
   """
   mkdir data

--- a/modules/render_pyramid.nf
+++ b/modules/render_pyramid.nf
@@ -5,8 +5,8 @@ process render_pyramid {
       tuple val(meta), file(image), file (story)
   output:
       tuple val(meta), path('minerva')
-  publishDir "$params.outdir/$workflow.runName",
-    saveAs: {filename -> "${meta.id}/$workflow.runName/minerva"}
+  publishDir "$params.outdir",
+    saveAs: {filename -> "${meta.id}/minerva"}
   stub:
   """
   mkdir minerva


### PR DESCRIPTION
Per the current README.md, we had intended to simplify the output structure to remove the nested workflow run name folders. However this had not been implemented.

This PR simplifies the output structure as intended