### PR TITLE
Fix samplesheet location for test profile

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -20,6 +20,6 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input = 'data/test_samplesheet.csv'
+    input = '${projectDir}/data/test_samplesheet.csv'
 
 }


### PR DESCRIPTION
Currently the test profile fails if run from outside the project directory.

This explicitly PR declares in the test config that the test samplesheet is nested under the projectDir. 