### PR TITLE
Update ome_types version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN source /venv/bin/activate && \
     pip install opencv-python-headless \
     pip install synapseclient \
     pip install mantel \
-    pip install ome_types
+    pip install ome_types>=0.4.2
 
 ENV VIRTUAL_ENV=/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"


### PR DESCRIPTION
The latest ome_types release v0.4.2 contains a fix for a [bug in pydantic-extra-types](https://github.com/pydantic/pydantic-extra-types/issues/87).

https://github.com/tlambert03/ome-types/releases/tag/v0.4.2

We should update the Dockerfile to specify the latest version.
